### PR TITLE
Catch bad peerid and update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,28 +43,28 @@
     "Victor Bjelkholm <victorbjelkholm@gmail.com>"
   ],
   "devDependencies": {
-    "aegir": "^15.2.0",
+    "aegir": "^17.0.1",
     "assert": "^1.4.1",
-    "chai": "^4.1.2",
+    "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "libp2p": "~0.23.0",
-    "libp2p-secio": "~0.10.0",
+    "libp2p": "~0.23.1",
+    "libp2p-secio": "~0.10.1",
     "pull-protocol-buffers": "~0.1.2",
-    "sinon": "^6.3.4"
+    "sinon": "^7.1.1"
   },
   "dependencies": {
-    "async": "^2.6.0",
-    "debug": "^4.0.1",
+    "async": "^2.6.1",
+    "debug": "^4.1.0",
     "defaults-deep": "~0.2.4",
     "interface-connection": "~0.3.2",
-    "mafmt": "^6.0.0",
-    "multiaddr": "^5.0.0",
-    "multistream-select": "~0.14.1",
-    "peer-id": "~0.11.0",
+    "mafmt": "^6.0.2",
+    "multiaddr": "^5.0.2",
+    "multistream-select": "~0.14.3",
+    "peer-id": "~0.12.0",
     "peer-info": "~0.14.1",
     "protons": "^1.0.1",
     "pull-abortable": "^4.1.1",
     "pull-handshake": "^1.1.4",
-    "pull-stream": "^3.6.7"
+    "pull-stream": "^3.6.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "coverage-publish": "aegir coverage --provider coveralls"
   },
   "pre-push": [
-    "lint",
-    "test"
+    "lint"
   ],
   "repository": {
     "type": "git",

--- a/src/circuit/dialer.js
+++ b/src/circuit/dialer.js
@@ -92,7 +92,7 @@ class Dialer {
    *
    * @param {PeerInfo} peer
    * @param {Function} callback
-   * @returns {*}
+   * @returns {void}
    */
   canHop (peer, callback) {
     callback = once(callback || (() => { }))
@@ -253,7 +253,7 @@ class Dialer {
    *
    * @param {PeerInfo} peer - the PeerInfo of the relay peer
    * @param {Function} cb - a callback with the connection to the relay peer
-   * @returns {Function|void}
+   * @returns {void}
    * @private
    */
   _dialRelay (peer, cb) {

--- a/src/circuit/dialer.js
+++ b/src/circuit/dialer.js
@@ -209,6 +209,12 @@ class Dialer {
       waterfall([
         (cb) => {
           log(`negotiating relay for peer ${dstMa.getPeerId()}`)
+          let dstPeerId
+          try {
+            dstPeerId = PeerId.createFromB58String(dstMa.getPeerId()).id
+          } catch (err) {
+            return cb(err)
+          }
           sh.write(
             proto.CircuitRelay.encode({
               type: proto.CircuitRelay.Type.HOP,
@@ -217,7 +223,7 @@ class Dialer {
                 addrs: srcMas.map((addr) => addr.buffer)
               },
               dstPeer: {
-                id: PeerId.createFromB58String(dstMa.getPeerId()).id,
+                id: dstPeerId,
                 addrs: [dstMa.buffer]
               }
             }), cb)

--- a/src/circuit/hop.js
+++ b/src/circuit/hop.js
@@ -124,7 +124,7 @@ class Hop extends EE {
    * @param {PeerInfo} peer
    * @param {StreamHandler} srcSh
    * @param {function} callback
-   * @returns {function}
+   * @returns {void}
    */
   _connectToStop (peer, srcSh, callback) {
     this._dialPeer(peer, (err, dstConn) => {
@@ -156,7 +156,7 @@ class Hop extends EE {
    * @param {StreamHandler} srcSh
    * @param {CircuitRelay} message
    * @param {function} callback
-   * @returns {function}
+   * @returns {void}
    */
   _negotiateStop (dstSh, srcSh, message, callback) {
     const stopMsg = Object.assign({}, message, {
@@ -241,7 +241,7 @@ class Hop extends EE {
    *
    * @param {Multiaddr} dstPeer
    * @param {Function} callback
-   * @returns {Function|void}
+   * @returns {void}
    * @private
    */
   _dialPeer (dstPeer, callback) {


### PR DESCRIPTION
Doing some stability tests on ipfs using the latest libp2p I received an error trying to get the peer id from and address. The error is below.  If the circuit dialer gets an address that is lacking a peer id, it will attempt to construct the id, but does not catch errors if the id is invalid.  This PR fixes that by wrapping the PeerId creation in a try catch. I've added a test verifying the issue and fix.

This also updates dependencies.

```
/Users/jacobheun/git/ipfs/js-libp2p-switch/node_modules/base-x/index.js:78
    if (typeof source !== 'string') throw new TypeError('Expected String')
                                    ^

TypeError: Expected String
    at decodeUnsafe (/Users/jacobheun/git/ipfs/js-libp2p-switch/node_modules/base-x/index.js:78:43)
    at Object.decode (/Users/jacobheun/git/ipfs/js-libp2p-switch/node_modules/base-x/index.js:139:20)
    at Object.fromB58String (/Users/jacobheun/git/ipfs/js-libp2p-switch/node_modules/multihashes/src/index.js:68:27)
    at Function.exports.createFromB58String (/Users/jacobheun/git/ipfs/js-libp2p-switch/node_modules/libp2p-circuit/node_modules/peer-id/src/index.js:169:24)
    at waterfall (/Users/jacobheun/git/ipfs/js-libp2p-switch/node_modules/libp2p-circuit/src/circuit/dialer.js:220:28)
    at nextTask (/Users/jacobheun/git/ipfs/js-libp2p-switch/node_modules/async/waterfall.js:16:14)
    at exports.default (/Users/jacobheun/git/ipfs/js-libp2p-switch/node_modules/async/waterfall.js:26:5)
    at _dialRelayHelper (/Users/jacobheun/git/ipfs/js-libp2p-switch/node_modules/libp2p-circuit/src/circuit/dialer.js:209:7)
    at f (/Users/jacobheun/git/ipfs/js-libp2p-switch/node_modules/once/once.js:25:25)
    at swarm.dial.once (/Users/jacobheun/git/ipfs/js-libp2p-switch/node_modules/libp2p-circuit/src/circuit/dialer.js:264:9)
```