### PR TITLE
chore: dont format logs in advance

### DIFF
--- a/src/circuit/dialer.js
+++ b/src/circuit/dialer.js
@@ -119,7 +119,7 @@ class Dialer {
           return callback(err)
         }
 
-        log(`HOP supported adding as relay - ${this.utils.getB58String(peer)}`)
+        log('HOP supported adding as relay - %s', this.utils.getB58String(peer))
         this.relayPeers.set(this.utils.getB58String(peer), peer)
         sh.close()
         callback()
@@ -175,7 +175,7 @@ class Dialer {
         dstMa,
         (err, conn) => {
           if (err) {
-            log.err(`An error has occurred negotiating the relay connection`, err)
+            log.err('An error has occurred negotiating the relay connection', err)
             return cb(err)
           }
 
@@ -207,7 +207,7 @@ class Dialer {
       let sh = new StreamHandler(conn)
       waterfall([
         (cb) => {
-          log(`negotiating relay for peer ${dstMa.getPeerId()}`)
+          log('negotiating relay for peer %s', dstMa.getPeerId())
           let dstPeerId
           try {
             dstPeerId = PeerId.createFromB58String(dstMa.getPeerId()).id

--- a/src/circuit/hop.js
+++ b/src/circuit/hop.js
@@ -98,7 +98,7 @@ class Hop extends EE {
       message.dstPeer.addrs.push(addr)
     }
 
-    log(`trying to establish a circuit: ${srcPeerId} <-> ${dstPeerId}`)
+    log('trying to establish a circuit: %s <-> %s', srcPeerId, dstPeerId)
     const noPeer = () => {
       // log.err(err)
       this.utils.writeResponse(
@@ -252,7 +252,7 @@ class Hop extends EE {
         dst,
         src
       )
-      log(`circuit ${srcIdStr} <-> ${dstIdStr} established`)
+      log('circuit %s <-> %s established', srcIdStr, dstIdStr)
       callback()
     })
   }


### PR DESCRIPTION
This moves the responsibility of the formatting of logs into the debug module, so that it can check the enabled status prior to formatting. This is more performant.