### PR TITLE
chore: add discourse badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # js-libp2p-circuit
 
+
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
-[![Build Status](https://travis-ci.com/libp2p/js-libp2p-circuit.svg?style=flat-square)](https://travis-ci.com/libp2p/js-libp2p-circuit)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
 [![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
-[![codecov](https://codecov.io/gh/libp2p/js-libp2p-circuit/branch/master/graph/badge.svg)](https://codecov.io/gh/libp2p/js-libp2p-circuit)
+[![Discourse posts](https://img.shields.io/discourse/https/discuss.libp2p.io/posts.svg)](https://discuss.libp2p.io)
+[![](https://img.shields.io/travis/libp2p/js-libp2p-circuit.svg?style=flat-square)](https://travis-ci.com/libp2p/js-libp2p-circuit)
+[![](https://img.shields.io/codecov/c/github/libp2p/js-libp2p-circuit.svg?style=flat-square)](https://codecov.io/gh/libp2p/js-libp2p-circuit)
 [![Dependency Status](https://david-dm.org/libp2p/js-libp2p-circuit.svg?style=flat-square)](https://david-dm.org/libp2p/js-libp2p-circuit)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
-![](https://img.shields.io/badge/npm-%3E%3D6.0.0-orange.svg?style=flat-square)
-![](https://img.shields.io/badge/Node.js-%3E%3D10.0.0-orange.svg?style=flat-square)
 
 ![](https://raw.githubusercontent.com/libp2p/interface-connection/master/img/badge.png)
 ![](https://raw.githubusercontent.com/libp2p/interface-transport/master/img/badge.png)

--- a/package.json
+++ b/package.json
@@ -50,26 +50,26 @@
     "dirkmc <dirk@mccormick.cx>"
   ],
   "devDependencies": {
-    "aegir": "^18.1.0",
+    "aegir": "^18.2.2",
     "chai": "^4.2.0",
     "dirty-chai": "^2.0.1",
-    "libp2p": "~0.24.4",
+    "libp2p": "~0.25.0",
     "libp2p-secio": "~0.11.1",
     "pull-protocol-buffers": "~0.1.2",
-    "sinon": "^7.2.3"
+    "sinon": "^7.3.1"
   },
   "dependencies": {
     "async": "^2.6.2",
     "debug": "^4.1.1",
     "interface-connection": "~0.3.3",
-    "mafmt": "^6.0.6",
-    "multiaddr": "^6.0.4",
+    "mafmt": "^6.0.7",
+    "multiaddr": "^6.0.6",
     "once": "^1.4.0",
     "peer-id": "~0.12.2",
     "peer-info": "~0.15.1",
     "protons": "^1.0.1",
     "pull-handshake": "^1.1.4",
-    "pull-length-prefixed": "^1.3.1",
+    "pull-length-prefixed": "^1.3.2",
     "pull-pair": "^1.1.0",
     "pull-stream": "^3.6.9"
   }


### PR DESCRIPTION
In the context of [libp2p/libp2p#74](https://github.com/libp2p/libp2p/issues/74), the badge for [discuss.libp2p.io](http://discuss.libp2p.io) was added.

Dependencies were also updated