### PR TITLE
fix: shim setImmediate in browser

### DIFF
--- a/src/circuit/dialer.js
+++ b/src/circuit/dialer.js
@@ -3,6 +3,7 @@
 const once = require('once')
 const PeerId = require('peer-id')
 const waterfall = require('async/waterfall')
+const setImmediate = require('async/setImmediate')
 const multiaddr = require('multiaddr')
 
 const Connection = require('interface-connection').Connection

--- a/src/circuit/hop.js
+++ b/src/circuit/hop.js
@@ -12,6 +12,7 @@ const proto = require('../protocol').CircuitRelay
 const multiaddr = require('multiaddr')
 const series = require('async/series')
 const waterfall = require('async/waterfall')
+const setImmediate = require('async/setImmediate')
 
 const multicodec = require('./../multicodec')
 


### PR DESCRIPTION
Adding condig to use webrtc in a js-ipfs browser node as per
https://github.com/ipfs/js-ipfs#how-to-enable-webrtc-support-for-js-ipfs-in-the-browser

triggered errors about unqualifed setImmediate use in dialler.

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>