### PR TITLE
chore: add deprecation notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+⛔️ DEPRECATED: libp2p-circuit is now included in [js-libp2p](https://github.com/libp2p/js-libp2p)
+======
+
 # js-libp2p-circuit
 
 


### PR DESCRIPTION
Circuit is now part of the js-libp2p repo.